### PR TITLE
[fix] corrected the 3d path name for Molex_Microfit3_Header_02x09_Angled

### DIFF
--- a/Molex_Microfit3_Header_02x09_Angled_43045-180x.kicad_mod
+++ b/Molex_Microfit3_Header_02x09_Angled_43045-180x.kicad_mod
@@ -35,7 +35,7 @@
   (pad 18 thru_hole circle (at -24 -3) (size 1.5 1.5) (drill 1.1) (layers *.Cu *.Mask))
   (pad 9 thru_hole circle (at -24 0) (size 1.5 1.5) (drill 1.1) (layers *.Cu *.Mask))
   (pad "" np_thru_hole circle (at -21.8 4.32) (size 3.1 3.1) (drill 3.1) (layers *.Cu *.Mask))
-  (model ${KISYS3DMOD}/Connectors_Molex.3dshapes/Microfit3 02x09 heder angled 43045-1800.wrl
+  (model ${KISYS3DMOD}/Connectors_Molex.3dshapes/Molex_Microfit3_Header_02x09_Angled_43045-180x.wrl
     (at (xyz 0 0 0))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))


### PR DESCRIPTION
This is the fix for https://github.com/KiCad/Connectors_Molex.pretty/issues/43

The 3d path had spaces in it.